### PR TITLE
Add Surrealist as open source project

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [ScriptBar](https://github.com/raguay/ScriptBarApp) - xBar done in a single window with outputs from a Node-Red server
 - [Bulletin Board](https://github.com/raguay/BulletinBoard) - A simple messaging dialog with user created templates.
 - [Owlly](https://github.com/asunlabs/owlly) - Let your Slack team know .env changes instantly with one single binary.
+- [Surrealist](https://github.com/StarlaneStudios/Surrealist) - An easy to use desktop app to build and test your SurrealDB queries
 
 ### Closed Source
 


### PR DESCRIPTION
I've recently used Wails to create [Surrealist](https://github.com/StarlaneStudios/Surrealist), an easy to use desktop app to build and test SurrealDB queries.

![image](https://user-images.githubusercontent.com/7606171/207644245-d601d3cd-dbd7-4fa0-8a2c-e367ad5bcba1.png)

SurrealDB is a relatively new graph-based database offering many modern features, however as it stands the only way to test your queries is using the command line, which of course gets tedious as your queries grow in size. That's why I created Surrealist to provide a graphical way to build, test, and explore your queries.

The app itself is built using Wails 2, React, and TypeScript. I'm currently packaging for windows (amd64) and Mac (arm64).