### PR TITLE
Added CFN Tracker

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,6 +59,7 @@ Wails のエコシステムとコミュニティから厳選された最高の�
 - [Optimus](https://github.com/Splode/optimus) - 画像の圧縮・最適化・変換を行うデスクトップアプリ
 - [Triangula GUI](https://github.com/RH12503/triangula-gui) - ポリゴン化した画像を生成するために Triangula を使用し、フロントエンドに Wails を使用した軽量なアプリ
 - [MT-SATA-server](https://github.com/newproplus/MT-SATA-server) - メタトレーダー向けの半自動取引アシスタント サーバー
+- [CFN Tracker](https://github.com/GreenSoap/cfn-tracker) - ストV CFN トラッカー
 
 ### クローズド ソース
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [GitHelper](https://github.com/xusenlin/git-helper) - a simple and beautiful git assistant.
 - [CryptoBox](https://github.com/istommao/CryptoBox) - a simple and useful cryptography toolbox
 - [MT-SATA-server](https://github.com/newproplus/MT-SATA-server) - Semi-automatic trading assistant server for metatrader.
+- [CFN Tracker](https://github.com/GreenSoap/cfn-tracker) - A tool for tracking any Street Fighter V CFN account's live match data
 
 ### Closed Source
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -63,6 +63,7 @@
 - [ScriptBar](https://github.com/raguay/ScriptBarApp) - 在单个窗口中完成的 xBar，输出来自 Node-Red 服务器。
 - [Bulletin Board](https://github.com/raguay/BulletinBoard) - 附带用户创建模板的简单消息对话框。
 - [MT-SATA-server](https://github.com/newproplus/MT-SATA-server) - 半自动 metatrader 交易助手
+- [CFN Tracker](https://github.com/GreenSoap/cfn-tracker) - 跟踪 街头霸王V CFN 帐户
 
 ### 闭源
 


### PR DESCRIPTION
<!-- Please describe your project in detail (including project repository, project website, screenshots, etc. to give others a quick overview of your project). -->

A tool to track any Street Fighter V account for its live match result data (using web scraping). The main purpose is for streamers to have automatically updated win/loss counters and other data displayed on their stream overlay. 

It uses [Rod](https://github.com/go-rod/rod) to poll the Street Fighter CFN website for changes. The frontend is created with React, TypeScript, Tailwind and Zustand.

<img src="https://raw.githubusercontent.com/GreenSoap/cfn-tracker/development/showcase/tracking.jpg" height="250px" align="right"/>

- [Repo](https://github.com/GreenSoap/cfn-tracker)
- [Website](https://greensoap.github.io/cfn-tracker/)