### PR TITLE
feat: add Krater to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [PasswordME](https://github.com/avelex/passwordme) - Tiny cross-platform password manager with generation
 - [Status Updater](https://github.com/turnkey-commerce/status-updater) - Accessible UI for users with limited vision to routinely update their status or request contact from remote caregivers.
 - [PF_Tools](https://github.com/pfinal-nc/wails_pf) - A simple cool clock desktop application
+
 ### Closed Source
 
 - [Xiaobaitu AI](https://xiaobaituai.com/download) - An easy-to-use artificial intelligence app
 - [Firebox](https://gitee.com/fireclub/firebox) - A desktop application developed based on riot LCU interface, for League of Legends
-
+- [Krater](https://moonguard.dev/krater) -  A lightweight, cross-platform desktop application that revolutionizes Laravel app debugging
 
 ## Tutorials
 


### PR DESCRIPTION
Added Krater to the closed source section of README.md.

NOTE: I am not affiliated with the project at all. It came up in my feed and I though it was cool. 

Krate is a debugging tool for Laravel applications. The authors promote is as a cross-platform desktop application. It offers different features that Laravel developers may find useful when working on their projects. Alas, I am not a Laravel developer, and so I cannot comment on how useful these tools and features may be. Regardless, I still think that it is an interesting thing to be able to pipe output from Laravel into a Wails application. 

While `moonguard`, the developers, do have open-source projects, from what I could gather,  Krater seems to be 
closed source. [This](https://blog.moonguard.dev/why-golang-instead-of-rust-to-develop-the-krater-desktop-app) is the official post about how the team switched from `Tuari` to `Wails` and it is here that I think they announce the product launch. [This](https://moonguard.dev/krater) is the product page. 

I have not personally downloaded the application yet, as I was mainly curious about why they could not make `Tauri` work. I did not even know `Wails` existed. But I am glad I did and Googled `different apps made using Wails`, which led me here. Since I do not have any screenshots with me, here are some supposed screenshots from the product page. 

![Screenshot 2023-11-08 at 6 06 10](https://github.com/wailsapp/awesome-wails/assets/56323498/53cd7aef-5ff2-470b-9f10-1dcaf69f07d1)

![Screenshot 2023-11-08 at 6 08 17](https://github.com/wailsapp/awesome-wails/assets/56323498/ba797a69-e2bb-4257-a9ff-2325c168ba7b)

![Screenshot 2023-11-08 at 6 08 49](https://github.com/wailsapp/awesome-wails/assets/56323498/d7e6141b-5057-414b-b715-56f9ca3bdac4)


