### PR TITLE
doc: Adds Go-Architect to Open Source Apps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [Status Updater](https://github.com/turnkey-commerce/status-updater) - Accessible UI for users with limited vision to routinely update their status or request contact from remote caregivers.
 - [PF_Tools](https://github.com/pfinal-nc/wails_pf) - A simple cool clock desktop application
 - [Swallow](https://github.com/rangwea/swallow-wails) - A cool static blog client.
+- [Go-Architect](https://github.com/go-architect/go-architect) - An Architecture Analysis Tool for Golang Projects.
 
 ### Closed Source
 


### PR DESCRIPTION
This PR adds Go-Architect (https://github.com/go-architect/go-architect/) to the list of Open Source Apps.

