### PR TITLE
Add Nuga

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [Go-Architect](https://github.com/go-architect/go-architect) - An Architecture Analysis Tool for Golang Projects.
 - [RemoteController](https://github.com/PiterWeb/RemoteController) - The Steam Remote Play Alternative powered by P2P & gamepads
 - [Tiny RDM](https://github.com/tiny-craft/tiny-rdm) - A modern lightweight cross-platform Redis desktop manager available for Mac, Windows, and Linux.
+- [Nuga](https://github.com/mishamyrt/nuga-app) - Application for controlling NuPhy® keyboards.
 
 ### Closed Source
 


### PR DESCRIPTION
Nuga is an application for customizing NuPhy keyboards. It supports macOS and Linux. Built on Svelte with the [Naco UI](https://naco.myrt.co/) graphics library, which is designed specifically for Wails.

![image](https://github.com/wailsapp/awesome-wails/assets/19162401/90437628-577c-41c2-8da8-00d5d6ff5472)
