### PR TITLE
feat: add SRSC-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [Sync Folder](https://github.com/zaaack/sync-folder) - A simple folder sync tray application, background memory usage is very low.
 - [serial reader window](https://github.com/nnttoo/serial_reader/) open-source application read data from serial ports (COM) on Windows
 - [PZ Admin](https://github.com/beyenilmez/pz-admin) - A desktop application for managing Project Zomboid servers with RCON.
+- [SRSC-Client](https://github.com/ooyyh/SRSC-Client) - A simple S3 object storage client that can theoretically support the management of all buckets compatible with the S3 protocol
 
 ### Closed Source
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -91,7 +91,8 @@
 - [wechatDataBackup](https://github.com/git-jiadong/wechatDataBackup) - 一款Windows PC端微信聊天记录数据导出浏览工具，界面与微信保持一致，使用简单方便。
 - [Kafka-King](https://github.com/Bronya0/Kafka-King) - 一个现代、实用的kafka本地客户端.
 - [go-stock](https://github.com/ArvinLovegood/go-stock) - 自选股票行情获取，成本盈亏展示,涨跌报警推送。数据全部保留在本地
--[Sync Folder](https://github.com/zaaack/sync-folder) - 一个简单的文件夹同步托盘应用，后台内存占用极少。
+- [Sync Folder](https://github.com/zaaack/sync-folder) - 一个简单的文件夹同步托盘应用，后台内存占用极少。
+- [SRSC-Client](https://github.com/ooyyh/SRSC-Client) - 一个简单的S3对象存储客户端，理论上可以支持管理所有兼容S3协议的存储桶
 
 ### 闭源
 


### PR DESCRIPTION
My project is a simple client written with the wails framework that can use the S3 protocol to connect and manage personal storage buckets. It has implemented the functions of uploading, downloading information in the bucket, and obtaining detailed information. At present, the mainstream Cloudflare R2 storage bucket and BackBlaze B2 storage bucket on the market can be connected and managed normally. This project is committed to breaking the shortcoming that S3 Browser only supports free connection to two accounts.
![image](https://github.com/user-attachments/assets/1d1299cf-9a6d-459f-85d3-5cff57d75bef)
![image](https://github.com/user-attachments/assets/a71f5dc8-705d-4158-9463-58ec8627c9e2)
![image](https://github.com/user-attachments/assets/8c1f7b77-bf5e-4f25-943f-b39e65263f74)

