### PR TITLE
Add Peirato's Piano to projects in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,5 +127,6 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [Build a cross-platform desktop application with Go and Wails](https://www.twilio.com/blog/build-cross-platform-desktop-application-go-wails) - A tutorial by Twilio
 - [An introduction to Go, by leveraging your favorite JS flavor](https://dev.to/mvaodhan/an-introduction-to-go-by-leveraging-your-favorite-js-flavor-192o)
 - [flybird-m3u8downloader](https://github.com/youwen21/flybird-m3u8downloader) - An easy-to-use m3u8 downloader
+- [Peirato's Piano](https://piano.peirato.com/) - Lightweight desktop piano keyboard, supporting connection to MIDI devices.
 
 ## Articles

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -99,6 +99,7 @@
 - [小白兔 AI](https://xiaobaituai.com/download) - 一款专为内容创造者赋能的生产力 AI 工具箱。
 - [Firebox](https://github.com/LvBay/firebox) - 一个基于 riot LCU 接口开发的桌面应用，适用于英雄联盟。
 - [飞鸟视频下载器](https://github.com/youwen21/flybird-m3u8downloader) - 一个M3u8视频下载器，支持导出MP4。
+- [PP钢琴键盘](https://piano.peirato.com/) - 轻量桌面钢琴键盘，支持连接MIDI设备。
 
 ## 教程
 


### PR DESCRIPTION
Peirato's Piano is a lightweight desktop piano keyboard, supporting connection to MIDI devices.

<!-- Please describe your project in detail (including project repository, project website, screenshots, etc. to give others a quick overview of your project). -->
