### PR TITLE
Remove AeroMod from open source apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [Easygen](https://github.com/faith0831/easygen) - A simple and easy-to-use code generator that can effectively reduce repetitive work and improve development efficiency.
 - [Nui](https://natsnui.app/) - Free and Open Source NATS management GUI.  Easily manage your NATS core, streams and buckets.
 - [Gahara Video Editor](https://github.com/Gahara-Editor/gahara) - Vim Inspired Video Editor.
-- [AeroMod](https://github.com/fly2z/aeromod) - An external mod manager for Microsoft Flight Simulator.
 - [RocketBlend Desktop](https://github.com/rocketblend/rocketblend-desktop) - Standalone client, launcher and tools for Blender projects.
 - [Ai Gui](https://github.com/pwh-pwh/ai-gui) - A simple AI Q&A software developed using Wails for daily Q&A. The icons can be reduced for easy use at any time.
 - [Serpico](https://github.com/leoantony72/serpico) - File Organizer: organize files by year,month and file type.

--- a/README.ru.md
+++ b/README.ru.md
@@ -100,7 +100,6 @@
 - [Easygen](https://github.com/faith0831/easygen) - Простой и удобный генератор кода, который эффективно сокращает повторяющуюся работу и повышает эффективность разработки.
 - [Nui](https://natsnui.app/) - Бесплатный и открытый GUI для управления NATS. Легко управляйте ядром NATS, потоками и хранилищами.
 - [Gahara Video Editor](https://github.com/Gahara-Editor/gahara) - Видеоредактор, вдохновленный Vim.
-- [AeroMod](https://github.com/fly2z/aeromod) - Внешний менеджер модов для Microsoft Flight Simulator.
 - [RocketBlend Desktop](https://github.com/rocketblend/rocketblend-desktop) - Автономный клиент, лаунчер и инструменты для проектов Blender.
 - [Ai Gui](https://github.com/pwh-pwh/ai-gui) - Простое программное обеспечение для ежедневных вопросов и ответов с использованием AI, значки можно уменьшить для удобного использования в любое время.
 - [Serpico](https://github.com/leoantony72/serpico) - Органайзер файлов: организуйте файлы по году, месяцу и типу.


### PR DESCRIPTION
<!-- Please describe your project in detail (including project repository, project website, screenshots, etc. to give others a quick overview of your project). -->

Apparently they switched to Tauri in https://github.com/metebykl/aeromod/pull/9