### PR TITLE
 Add Pelton Email Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 ### Open Source
 
 - [uniTerm](https://github.com/ys-ll/uniterm) - A terminal software powered by an autonomous AI Agent, with full remote access support: SSH/Telnet/Mosh, SFTP/FTP, RDP/VNC/SPICE, database, SSH tunnel, and server monitor.
+- [Pelton](https://pelton.app) - *FOSS Email Client* with rich customizability and a focus on privacy. Built with Go, Svelte and ofc Wails.
 - [Klustr](https://github.com/SametKUM/klustr) - A fast, lightweight Kubernetes desktop client. Multi-cluster aggregation, live informer-driven UI, and built-in Helm, Argo CD, Flux CD and Gateway API support. Nothing is installed in the cluster.
 - [solo](https://github.com/raml-dev/solo) - The lightweight, fast, open-source API client for modern development.
 - [MockWails](https://github.com/tacheraSasi/mockwails) - A comprehensive desktop application for developers, testers, and API designers to create and manage mock HTTP servers efficiently.


### PR DESCRIPTION
Pelton is an open-source, self-hosted-friendly email client built with Go, Wails, and Svelte. Unlike most email clients, it's a native desktop app rather than an Electron wrapper, which keeps it lighter on resources while still using web tech (Svelte) for the UI layer.

The project is licensed under GPL-3.0, so it stays free and open. Forks and derivatives have to remain open too.

- Website: https://pelton.app
- Docs: https://docs.pelton.app
- Themes: https://themes.pelton.app
- Repository: https://github.com/TRC-Loop/Pelton

## Screenshot

<img width="2784" height="1928" alt="image" src="https://github.com/user-attachments/assets/263e3119-ca0f-4160-b9f1-1c6dc105ee10" />

<img width="1668" height="1107" alt="image" src="https://github.com/user-attachments/assets/c04705b8-d215-41ae-9562-bbcec535613a" />

<img width="1668" height="1107" alt="image" src="https://github.com/user-attachments/assets/353d0276-cef5-45fc-9a26-fe445cc5fd70" />

<img width="1668" height="1107" alt="image" src="https://github.com/user-attachments/assets/33d42d14-9353-476d-9004-da645a8de19c" />

<img width="1668" height="1107" alt="image" src="https://github.com/user-attachments/assets/a3546799-8a43-4e91-8d55-1dfaa701e88e" />

<img width="466" height="364" alt="image" src="https://github.com/user-attachments/assets/0470efd6-64f4-4d27-af9e-e4c96e9c1311" />


> The client isnt this bright, its because of my Monitor being HDR and Windows having a hard time ._.


**Onboarding**
<img width="1668" height="1107" alt="image" src="https://github.com/user-attachments/assets/d590e03d-c726-48ee-9de8-61ae84c326f0" />


The Client is still relatively new, so expect some bugs. Feedback and contributions are welcome via the repo.