### PR TITLE
docs: add Mercury to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [Open Photo AI](https://github.com/vegidio/open-photo-ai) - An open source alternative to the popular photo AI editor.
 - [BeamSync](https://github.com/PranavAgarkar07/BeamSync) - A cross-platform desktop app for fast, offline peer-to-peer file transfers over LAN, with QR code sharing, drag & drop, and zero cloud dependency.
 - [NetraX](https://github.com/jigarvarma2k20/NetraX) - HTTP traffic interception and security analysis toolkit and open source core alternative to the burp suit.
+- [Mercury](https://github.com/striker561/Mercury) - LAN clipboard and file sharing with AES-256-GCM encryption, zero-config mDNS discovery, no cloud or accounts.
 
 ### Closed Source
 


### PR DESCRIPTION
Adds [Mercury](https://github.com/striker561/Mercury) to Apps → Open Source.

A cross-platform (macOS/Linux/Windows) LAN clipboard and file-sharing app built with Wails v3 + React/TypeScript + Bun/Vite. Syncs copied text, images, and files between devices on the same network — AES-256-GCM encrypted from a shared passphrase, discovered via mDNS, tray-first, and deliberately cloud-free.

<img width="45%" height="100%" alt="image" src="https://github.com/user-attachments/assets/7920721d-ffb1-463d-ae70-510095ee4c12" />
<img width="45%" height="100%" alt="image" src="https://github.com/user-attachments/assets/f4249c30-db63-49ad-8f12-677dfc8ed292" />

